### PR TITLE
Attempt to "fix" cache "sticking"

### DIFF
--- a/lib/MojoX/Plugin/AnyCache/Backend/Memcached/Client.pm
+++ b/lib/MojoX/Plugin/AnyCache/Backend/Memcached/Client.pm
@@ -15,11 +15,9 @@ has 'get_ttl_support' => sub { 0 };
 
 sub get_memcached {
 	my ($self) = @_;
-	if(!$self->memcached) {
-		my %opts = ();
-		$opts{servers} = $self->config->{servers} if exists $self->config->{servers};
-		$self->memcached(Memcached::Client->new(%opts));
-	}
+    my %opts = ();
+	$opts{servers} = $self->config->{servers} if exists $self->config->{servers};
+	$self->memcached(Memcached::Client->new(%opts));
 	return $self->memcached;
 }
 


### PR DESCRIPTION
Attempt to address the issue of sessions "sticking" when used with MojoX::Security::Session.

This issue manifests when some requests (not reliably replicable) "stick" - the `get` call to `memcached` doesn't return and the mojolicious request times out. Subsequent calls then mostly just timeout.

Creating a new instance of `Memcached::Client` each request doesn't suffer from the issue but feels wrong currently.
